### PR TITLE
fixes to handle permissions and first run of the wepbart

### DIFF
--- a/Webpart/src/webparts/personalTiles/components/mainLayout/PersonalTiles.tsx
+++ b/Webpart/src/webparts/personalTiles/components/mainLayout/PersonalTiles.tsx
@@ -70,7 +70,12 @@ export default class PersonalTiles extends React.Component<IPersonalTilesProps, 
             this.state.tileItemsService
               .checkIfAppDataFolderExists()
               .then(appDataFolderExists => {
-                if (!appDataFolderExists) {
+                if (appDataFolderExists.isError) {
+                  this.setState({
+                    isError: true,
+                    errorDescription: appDataFolderExists.errorMessage
+                  });
+                } else if (!appDataFolderExists.folderExists) {
                   this.state.tileItemsService
                     .createAppDataFolder()
                     .then(folderName => {

--- a/Webpart/src/webparts/personalTiles/model/tileItemsService/IAppDataFolderExistsOutput.ts
+++ b/Webpart/src/webparts/personalTiles/model/tileItemsService/IAppDataFolderExistsOutput.ts
@@ -1,0 +1,5 @@
+export default interface IAppDataFolderExistsOutput {
+    isError: boolean;
+    errorMessage: string;
+    folderExists: boolean;
+}


### PR DESCRIPTION
### ✔ What was done
- fixed presenting bug when user did not approve graph api permissions for webpart 
- fixed presenting first run of app showing that user has not data (tiles) yet

### 📸 Result
when user did not consent to the graph permissions
![image](https://user-images.githubusercontent.com/58668583/111888214-cff8d880-89da-11eb-933e-4228300119da.png)

when user has no tiles (first webpart run)
![image](https://user-images.githubusercontent.com/58668583/111888218-d8511380-89da-11eb-85da-693046b6cc8b.png)
